### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,14 @@ setup(
     name='MetaModule',
     version='0.1.0',
     description='MetaModule provides extensions of PyTorch Module for meta learning',
-    license='MIT',
     author='Zhi Zhang',
     author_email='yhqjohn@gmail.com',
     keywords=['pytorch', 'meta learning'],
     url='https://github.com/yhqjohn/MetaModule',
     packages=find_packages(exclude=['tests']),
     long_description=readme,
-    setup_requires=requirements
+    setup_requires=requirements,
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+    ],
 )


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.